### PR TITLE
Added first breakfix scenario via breakfix1 role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test
 tar-backup/*
 *.log
 ansible.cfg
+inventory

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# TestRepo
-This is to test some git stuff
+# To develop breakfix scenarios for a Red Hat Satellite based infrastructure.
+
+## Author, Copyright and License
+This project is initiated by Sayan Das <saydas@redhat.com>, <connectwithsayan03@gmail.com>. It's further being assisted by personA personB and personC. It is free software licensed under the terms of the GNU General Public License GPL v3 or later. A copy of the license can be obtained here: http://www.gnu.org/licenses/gpl-3.0.html
+
+## Motivation!
+
+Basic training sessions on individual topics of Red Hat Satellite is not good enough to make someone a good **Administrator of Red Hat Satellite** or **Support Engineer for Red Hat Satellite** product. It's important to understand 
+* How the product works in the backend
+* How end-users are using it in their own environments
+* What types of problems are being reported by the end-users
+* And most importantly
+    - How to investigate them ?
+    - What data to ask for ?
+    - What logs files to inspect ?
+    - How to find out a suitable solution to fix the problem ?
+    
+The breakfix modules are developed by combining real-world examples with support-team's experiences and our goal is to make sure that, the audience slowly starts understanding the objectives mentioned earlier, while going through the different modules.
+
+
+## Things covered in this project
+The project would consist of individual ansible roles for individual breakfix modules that we plan to develop. It's recommended to read through the **README.md** file of individual ansible roles to understand their usage and purposes.
+
+## Compatibility
+The roles were tested to be working with Satellite Version 6.14 and later.
+
+## Prerequisites
+
+#### Note: It's recommended to have some basic **Ansible** and **Red Hat Satellite** knowledge to operate and use this project.
+
+* Make sure to have a standard Red Hat Satellite + Capsule deployment and one or more RHEL systems build to act as client systems. 
+
+* Make sure that each of those systems have the following commands executed.
+
+   ~~~
+   # useradd ec2-user;
+   # echo 'ec2-user:password@123' | /usr/sbin/chpasswd;
+   # echo "ec2-user   ALL=NOPASSWD:   ALL" | tee -a /etc/sudoers.d/ec2-user;
+   ~~~
+
+* Determine your bastion\master system and make sure that the master system can talk to the Satellite\Capsule\RHEL-Clients over SSH using the ec2-user without any password. 
+
+
+## How to use
+
+* Fork the project and clone it in your master\bastion node.
+
+* Copy `ansible.cfg.example` by name `ansible.cfg` and make changed in the file as per your requirements.
+
+* Create an `inventory` file e.g. 
+
+   ~~~
+   # cat inventory
+   [localhost]
+   127.0.0.1 ansible_connection=local ansible_become=false
+
+   [satellite]
+   satellite615.lab.example.com
+   
+   [capsule]
+   capsule615.lab.example.com
+
+   [client]
+   rhel8.lab.example.com
+   ~~~
+
+* **IMPORTANT!** Edit the `requirements.yml` file to ensure all required collections are part of this file. And then install the collections using this command i.e. 
+
+   ~~~
+   # ansible-galaxy install -r requirements.yml
+   ~~~
+   
+* Refer to the **README.md** and `vars/main.yml` of each ansible role and make sure all the pre-requisites have been fulfilled e.g. installation of additional ansible modules or updating the variable values.
+
+* Execute the roles in the following way i.e. 
+
+   ~~~
+   # ansible-playbook -i inventory breakfix1.yaml
+   ~~~
+
+
+
+## Contributions
+Contributions are very welcome :-) Just send me a pull-request
+
+

--- a/ansible.cfg.example
+++ b/ansible.cfg.example
@@ -1,0 +1,14 @@
+[defaults]
+#inventory = ./inventory
+ask_pass = False
+host_key_checking = False
+remote_user = ec2-user
+timeout = 30
+stdout_callback = yaml
+
+[privilege_escalation]
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False
+

--- a/breakfix1.yaml
+++ b/breakfix1.yaml
@@ -1,0 +1,6 @@
+---
+- name: Deploy ansible role breakfix1 on target systems
+  hosts: satellite
+  roles:
+    - role: breakfix1
+      tags: break

--- a/breakfix1/README.md
+++ b/breakfix1/README.md
@@ -1,0 +1,61 @@
+breakfix1
+=========
+
+This role targets to break a satellite and capsule server in a way that, neither hosts will be able to download patches from them nor any repos can be successully resynced on the satellite. 
+
+Example Error:
+
+Status code: 500  when trying to install\update packages on the RHEL systems connected with the satellite server through a capsule server.
+
+~~~
+[MIRROR] katello-host-tools-4.2.3-5.el8sat.noarch.rpm: Status code: 500 for https://capsule.example.com/pulp/content/RedHat/Library/content/dist/layered/rhel8/x86_64/sat-client/6/os/Packages/k/katello-host-tools-4.2.3-5.el8sat.noarch.rpm (IP: XX.XX.XXX.XXX)
+~~~
+
+What we essentially do by this ansible role is:
+
+* Confirm that the satellite is running
+* Create an activation key
+* Generate a registration command [ via Global registration method ] to register a host through the external capsule server
+* Execute the command on the client and register it
+* Update database records of satellite and capsule to break them.
+
+
+Requirements
+------------
+
+This ansible role requires the [foreman ansible modules](https://github.com/theforeman/foreman-ansible-modules/). Please install them before executing the role.
+
+Role Variables
+--------------
+
+The `vars/main.yml` file contains the required variables for the ansible role. Adjust the values according to your environment.
+
+Dependencies
+------------
+
+NA
+
+Example Playbook
+----------------
+
+This ansible role can be executed after creating a playbook in the following way. 
+
+~~~
+# cat breakfix1.yaml
+---
+- name: Deploy ansible role breakfix1 on target systems
+  hosts: satellite
+  roles:
+    - role: breakfix1
+      tags: break
+~~~
+
+License
+-------
+
+It is free software licensed under the terms of the GNU General Public License GPL v3 or later. A copy of the license can be obtained here: http://www.gnu.org/licenses/gpl-3.0.html
+
+Author Information
+------------------
+
+This role is developed by Sayan Das <saydas@redhat.com>, <connectwithsayan03@gmail.com>. 

--- a/breakfix1/tasks/main.yml
+++ b/breakfix1/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+# tasks file for breakfix1
+- name: Set initial facts
+  ansible.builtin.set_fact:
+    satellite_hostname: "{{ ansible_fqdn }}"
+
+- name: Ensure satellite is running.
+  theforeman.foreman.status_info:
+    server_url: "https://{{ satellite_hostname }}"
+    username: "{{ satellite_login['username'] }}"
+    password: "{{ satellite_login['password'] }}"
+    validate_certs: false
+  register: status_info
+
+- name: Create client activation key
+  theforeman.foreman.activation_key:
+    server_url: "https://{{ satellite_hostname }}"
+    username: "{{ satellite_login['username'] }}"
+    password: "{{ satellite_login['password'] }}"
+    validate_certs: false
+    name: "{{ activation_key }}"
+    organization: "{{ satellite_organization }}"
+    lifecycle_environment: "Library"
+    content_view: "Default Organization View"
+  when: status_info['status']['result'] == "ok"
+  register: ak_created
+
+- name: Generate registration command to register the system with Capsule server
+  theforeman.foreman.registration_command:
+    server_url: "https://{{ satellite_hostname }}"
+    username: "{{ satellite_login['username'] }}"
+    password: "{{ satellite_login['password'] }}"
+    validate_certs: false
+    setup_remote_execution: true
+    setup_insights: false
+    jwt_expiration: 8
+    force: true
+    insecure: true
+    activation_keys: "{{ activation_key }}"
+    organization: "{{ satellite_organization }}"
+    location: "{{ satellite_location }}"
+    smart_proxy: "{{ groups['capsule'][0] }}"
+  when: ak_created is success
+  register: global_reg_command
+
+- name: Regsiter the client host
+  ansible.builtin.command: bash -c "{{ global_reg_command['registration_command'] }}"
+  delegate_to: "{{ groups['client'][0] }}"
+  register: host_registration
+  when: global_reg_command is defined
+
+- name: Break the satellite by adding a proxy in repositories to fail the sync.
+  ansible.builtin.command: >
+    su - postgres -c "psql pulpcore -c 'update core_remote set proxy_url = '\''http://localhost:3128'\'' where pulp_type = '\''rpm.rpm'\'';'"
+  register: break_satellite
+  when:
+    - status_info['status']['result'] == "ok"
+    - host_registration is success
+
+- name: Break the capsule by adding a proxy in repositories to fail content retrieval from capsule.
+  ansible.builtin.command: >
+    su - postgres -c "psql pulpcore -c 'update core_remote set proxy_url = '\''http://localhost:3128'\'' where pulp_type = '\''rpm.rpm'\'';'"
+  delegate_to: "{{ groups['capsule'][0] }}"
+  register: break_capsule
+  when: break_satellite is success

--- a/breakfix1/vars/main.yml
+++ b/breakfix1/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# vars file for breakfix1
+satellite_organization: "RedHat"
+satellite_location: "GSS"
+satellite_login:
+  username: "admin"
+  password: "RedHat1!"
+activation_key: "RHEL-AK"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,7 @@
+---
+collections:
+  - name: https://github.com/theforeman/foreman-ansible-modules.git
+    type: git
+    version: develop
+  - name: ansible.posix
+  - name: community.general

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-this is my first commit

--- a/test2.txt
+++ b/test2.txt
@@ -1,1 +1,0 @@
-This is my first breakfix


### PR DESCRIPTION
Added first breakfix scenario via breakfix1 role. This one serves as an example for future developments. 

I also made sure that it had minimum possible linting issues. JFYI, the result:

~~~
# ansible-lint breakfix1.yaml
WARNING  Skipped installing collection dependencies due to running in offline mode.
WARNING  Listing 3 violation(s) that are fatal
no-changed-when: Commands should not change things if nothing needs doing.
breakfix1/tasks/main.yml:46 Task/Handler: Regsiter the client host

no-changed-when: Commands should not change things if nothing needs doing.
breakfix1/tasks/main.yml:52 Task/Handler: Break the satellite by adding a proxy in repositories to fail the sync.

no-changed-when: Commands should not change things if nothing needs doing.
breakfix1/tasks/main.yml:60 Task/Handler: Break the capsule by adding a proxy in repositories to fail content retrieval from capsule.

Read documentation for instructions on how to ignore specific rule violations.

                  Rule Violation Summary                  
 count tag             profile rule associated tags       
     3 no-changed-when shared  command-shell, idempotency 

Failed: 3 failure(s), 0 warning(s) on 3 files. Last profile that met the validation criteria was 'safety'. Rating: 3/5 star

~~~